### PR TITLE
Enable word wrapping

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,6 +18,7 @@ require(['vs/editor/editor.main'], function() {
         value: '',
         language: 'text',
         theme: 'error',
+        wordWrap: 'on',
         minimap: {
             enabled: false
         }
@@ -40,6 +41,7 @@ require(['vs/editor/editor.main'], function() {
         value: '',
         language: 'json',
         theme: 'error',
+        wordWrap: 'on',
         minimap: {
             enabled: false
         },


### PR DESCRIPTION
## Summary
- enable word wrapping for the source and destination Monaco editors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c9db9bb14832f87ca2e6b1c8713ab